### PR TITLE
remove redundant polls from pyzmq implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ A simple benchmark suite to compare the performance of a various combination of 
 
 An example run with Python 3.5.1, Tornado 4.3, uvloop 0.4.33, PyZMQ 15.3.0, aiozmq 0.7.1 on MacOS X 10.11 (64bit) results in:
 ```
-asyncio + aiozmq: 0.388407 sec.
-tornado + aiozmq: 0.501667 sec.
-uvloop + aiozmq: 0.214249 sec.
-zmqloop + pyzmq: 1.406731 sec.
-tornado + pyzmq: 2.261831 sec.
+asyncio + aiozmq: 0.363527 sec.
+tornado + aiozmq: 0.418002 sec.
+uvloop + aiozmq: 0.182694 sec.
+zmqloop + pyzmq: 0.704048 sec.
+tornado + pyzmq: 1.093527 sec.
 ```

--- a/test-tornado-pyzmq.py
+++ b/test-tornado-pyzmq.py
@@ -19,15 +19,11 @@ async def pushing():
 async def pulling():
     client = ctx.socket(zmq.PULL)
     client.connect('tcp://127.0.0.1:9000')
-    poller = zmq.asyncio.Poller()
-    poller.register(client, zmq.POLLIN)
     with open(os.devnull, 'w') as null:
         while True:
-            events = await poller.poll()
-            if client in dict(events):
-                greeting = await client.recv_multipart()
-                if greeting[0] == b'exit': break
-                print(greeting[0], file=null)
+            greeting = await client.recv_multipart()
+            if greeting[0] == b'exit': break
+            print(greeting[0], file=null)
 
 def main():
     loop = IOLoop.current()

--- a/test-zmqloop-pyzmq.py
+++ b/test-zmqloop-pyzmq.py
@@ -16,15 +16,11 @@ async def pushing():
 async def pulling():
     client = ctx.socket(zmq.PULL)
     client.connect('tcp://127.0.0.1:9000')
-    poller = zmq.asyncio.Poller()
-    poller.register(client, zmq.POLLIN)
     with open(os.devnull, 'w') as null:
         while True:
-            events = await poller.poll()
-            if client in dict(events):
-                greeting = await client.recv_multipart()
-                if greeting[0] == b'exit': break
-                print(greeting[0], file=null)
+            greeting = await client.recv_multipart()
+            if greeting[0] == b'exit': break
+            print(greeting[0], file=null)
 
 def main():
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
recv already blocks, so it is more equivalent to the other tests to skip the extra poll

this removes a factor of two from the pyzmq tests
